### PR TITLE
Fixed virtual terminal input sequence parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,69 @@
+`vty-windows` is a plugin for the vty terminal interface library. It provides 
+support for vty on the Windows platform. vty-windows is supported on GHC versions
+9.4.4 and up.
+
+Install via `git` with:
+
+```
+git clone git://github.com/chhackett/vty-windows.git
+```
+
+Install via `cabal` with:
+
+```
+cabal install vty
+```
+
+# Features
+
+* Supports Windows 10 since build 1703 (Creators Update added support for most VT sequences).
+
+* Automatically handles window resizes.
+
+* Supports Unicode output.
+
+* Automatically decodes keyboard keys into (key,[modifier]) tuples.
+
+* Provides extensible input and output interfaces.
+
+* Supports ANSI graphics modes (SGR as defined in `console_codes(4)`)
+  with a type-safe interface and graceful fallback for terminals
+  with limited or nonexistent support for such modes.
+
+* Properly handles cleanup.
+
+* Supports "normal" and "extended" (SGR) mouse modes as described at
+  http://invisible-island.net/xterm/ctlseqs/ctlseqs.html#h2-Mouse-Tracking
+
+* Supports bracketed paste mode as described at
+  http://cirw.in/blog/bracketed-paste
+
+* Supports multi-column Unicode characters such as emoji characters. In
+  cases where Vty and your terminal emulator disagree on character
+  widths, Vty provides a tool `vty-build-width-table` and library
+  functionality to build a width table that will work for your terminal
+  and load it on application startup.
+
+# Contributing
+
+If you decide to contribute, that's great! Here are some guidelines you
+should consider to make submitting patches easier for all concerned:
+
+ - Please ensure that the examples and test suites build along with the
+   library.
+ - If you make changes, make them consistent with the syntactic
+   conventions already used in the codebase.
+ - Please provide Haddock documentation for any changes you make.
+
+# Known Issues
+
+
+# Further Reading
+
+Good sources of documentation for terminal programming are:
+
+* https://github.com/b4winckler/vim/blob/master/src/term.c
+* http://invisible-island.net/xterm/ctlseqs/ctlseqs.html
+* http://ulisse.elettra.trieste.it/services/doc/serial/config.html
+* http://www.leonerd.org.uk/hacks/hints/xterm-8bit.html
+* http://vt100.net/docs/vt100-ug/chapter3.html

--- a/src/Graphics/Vty/Platform/Windows/Input/Classify.hs
+++ b/src/Graphics/Vty/Platform/Windows/Input/Classify.hs
@@ -38,8 +38,9 @@ compile table = cl' where
             -- if the inputBlock is exactly what is expected for an
             -- event then consume the whole block and return the event
             Just e -> Valid e BS8.empty
-            Nothing -> case S.member inputBlock prefixSet of
-                True -> Prefix
+            Nothing ->
+                if S.member inputBlock prefixSet
+                then Prefix
                 -- look up progressively smaller tails of the input
                 -- block until an event is found The assumption is that
                 -- the event that consumes the most input bytes should
@@ -47,7 +48,7 @@ compile table = cl' where
                 -- The test verifyFullSynInputToEvent2x verifies this.
                 -- H: There will always be one match. The prefixSet
                 -- contains, by definition, all prefixes of an event.
-                False ->
+                else
                     let inputPrefixes = reverse . take maxValidInputLength . tail . BS8.inits $ inputBlock
                     in case mapMaybe (\s -> (,) s `fmap` M.lookup s eventForInput) inputPrefixes of
                         (s,e) : _ -> Valid e (BS8.drop (BS8.length s) inputBlock)

--- a/src/Graphics/Vty/Platform/Windows/Input/Loop.hs
+++ b/src/Graphics/Vty/Platform/Windows/Input/Loop.hs
@@ -107,7 +107,7 @@ readFromDevice = do
 
     input <- lift ask
     stringRep <- liftIO $ do
-        bytesRead <- readBuf (eventChannel input) winRecordPtr handle bufferPtr maxInputRecords
+        bytesRead <- readBuf (eventChannel input) winRecordPtr handle bufferPtr maxInputRecords (inputLogMsg input)
         if bytesRead > 0
         then BS.packCStringLen (castPtr bufferPtr, fromIntegral bytesRead)
         else return BS.empty
@@ -148,6 +148,7 @@ dropInvalid = do
 
 runInputProcessorLoop :: ClassifyMap -> Input -> Handle -> IO ()
 runInputProcessorLoop classifyTable input handle = do
+    inputLogMsg input $ show classifyTable
     let bufferSize = 1024
     -- A key event could require 4 bytes of UTF-8.
     let maxKeyEvents = bufferSize `div` 4

--- a/src/Graphics/Vty/Platform/Windows/Input/Loop.hs
+++ b/src/Graphics/Vty/Platform/Windows/Input/Loop.hs
@@ -148,7 +148,6 @@ dropInvalid = do
 
 runInputProcessorLoop :: ClassifyMap -> Input -> Handle -> IO ()
 runInputProcessorLoop classifyTable input handle = do
-    inputLogMsg input $ show classifyTable
     let bufferSize = 1024
     -- A key event could require 4 bytes of UTF-8.
     let maxKeyEvents = bufferSize `div` 4

--- a/src/Graphics/Vty/Platform/Windows/Input/Terminfo.hs
+++ b/src/Graphics/Vty/Platform/Windows/Input/Terminfo.hs
@@ -5,9 +5,6 @@ where
 
 import Graphics.Vty.Input.Events
 import qualified Graphics.Vty.Platform.Windows.Input.Terminfo.ANSIVT as ANSIVT
-import Graphics.Vty.Platform.Windows.WindowsCapabilities ( getStringCapability )
-
-import Control.Arrow ( Arrow(first) )
 
 -- | Queries the terminal for all capability-based input sequences and
 -- then adds on a terminal-dependent input sequence mapping.
@@ -87,19 +84,15 @@ ctrlChars =
 ctrlMetaChars :: ClassifyMap
 ctrlMetaChars = map (\(s, EvKey c m) -> ('\ESC':s, EvKey c (MMeta:m))) ctrlChars
 
--- | Esc, meta-esc, delete, meta-delete, enter, meta-enter.
+-- | Escape, backspace, enter, tab.
 specialSupportKeys :: ClassifyMap
 specialSupportKeys =
-    [ ("\ESC\ESC[5~",EvKey KPageUp [MMeta])
-    , ("\ESC\ESC[6~",EvKey KPageDown [MMeta])
     -- special support for ESC
-    , ("\ESC",EvKey KEsc []), ("\ESC\ESC",EvKey KEsc [MMeta])
+    [ ("\ESC",EvKey KEsc []), ("\ESC\ESC",EvKey KEsc [MMeta])
     -- Special support for backspace
-    , ("\DEL",EvKey KBS []), ("\ESC\DEL",EvKey KBS [MMeta]), ("\b",EvKey KBS [])
+    , ("\DEL", EvKey KBS []), ("\ESC\DEL", EvKey KBS [MMeta]), ("\b", EvKey KBS [MCtrl])
     -- Special support for Enter
-    , ("\ESC\^J",EvKey KEnter [MMeta]), ("\r",EvKey KEnter [])
+    , ("\r",EvKey KEnter []), ("\ESC\^J",EvKey KEnter [MMeta]), ("\n", EvKey KEnter [MCtrl])
     -- explicit support for tab
-    , ("\t", EvKey (KChar '\t') [])
-    , ("\SUB", EvKey KPause [])
-    , ("\ESC[Z", EvKey KBackTab [])
+    , ("\t", EvKey (KChar '\t') []), ("\ESC[Z", EvKey (KChar '\t') [MShift])
     ]

--- a/src/Graphics/Vty/Platform/Windows/Input/Terminfo.hs
+++ b/src/Graphics/Vty/Platform/Windows/Input/Terminfo.hs
@@ -37,8 +37,7 @@ import Control.Arrow ( Arrow(first) )
 -- Precedence is currently implicit in the 'compile' algorithm.
 classifyMapForTerm :: ClassifyMap
 classifyMapForTerm =
-    concat $ capsClassifyMap keysFromCapsTable
-           : universalTable
+    concat $ universalTable
            : ANSIVT.classifyTable
 
 -- | The key table applicable to all terminals.
@@ -54,10 +53,6 @@ universalTable = concat
     , ctrlMetaChars
     , specialSupportKeys
     ]
-
-capsClassifyMap :: [(String,Event)] -> ClassifyMap
-capsClassifyMap table = [(x,y) | (Just x,y) <- map extractCap table]
-    where extractCap = first getStringCapability
 
 -- | Visible characters in the ISO-8859-1 and UTF-8 common set up to
 -- but not including those in the range 0xA1 to 0xC1
@@ -82,7 +77,7 @@ otherVisibleChars =
 -- This treats CTRL-i the same as tab.
 ctrlChars :: ClassifyMap
 ctrlChars =
-    [ ([toEnum x],EvKey (KChar y) [MCtrl])
+    [ ([toEnum x], EvKey (KChar y) [MCtrl])
     | (x,y) <- zip [0..31] ('@':['a'..'z']++['['..'_'])
     , y /= 'i'  -- Resolve issue #3 where CTRL-i hides TAB.
     , y /= 'h'  -- CTRL-h should not hide BS
@@ -102,90 +97,9 @@ specialSupportKeys =
     -- Special support for backspace
     , ("\DEL",EvKey KBS []), ("\ESC\DEL",EvKey KBS [MMeta]), ("\b",EvKey KBS [])
     -- Special support for Enter
-    , ("\ESC\^J",EvKey KEnter [MMeta]), ("\^J",EvKey KEnter [])
+    , ("\ESC\^J",EvKey KEnter [MMeta]), ("\r",EvKey KEnter [])
     -- explicit support for tab
     , ("\t", EvKey (KChar '\t') [])
+    , ("\SUB", EvKey KPause [])
+    , ("\ESC[Z", EvKey KBackTab [])
     ]
-
--- | A classification table directly generated from terminfo cap
--- strings.  These are:
---
--- * ka1 - keypad up-left
---
--- * ka3 - keypad up-right
---
--- * kb2 - keypad center
---
--- * kbs - keypad backspace
---
--- * kbeg - begin
---
--- * kcbt - back tab
---
--- * kc1 - keypad left-down
---
--- * kc3 - keypad right-down
---
--- * kdch1 - delete
---
--- * kcud1 - down
---
--- * kend - end
---
--- * kent - enter
---
--- * kf0 - kf63 - function keys
---
--- * khome - KHome
---
--- * kich1 - insert
---
--- * kcub1 - left
---
--- * knp - next page (page down)
---
--- * kpp - previous page (page up)
---
--- * kcuf1 - right
---
--- * kDC - shift delete
---
--- * kEND - shift end
---
--- * kHOM - shift home
---
--- * kIC - shift insert
---
--- * kLFT - shift left
---
--- * kRIT - shift right
---
--- * kcuu1 - up
-keysFromCapsTable :: ClassifyMap
-keysFromCapsTable =
-    [ ("ka1",   EvKey KUpLeft    [])
-    , ("ka3",   EvKey KUpRight   [])
-    , ("kb2",   EvKey KCenter    [])
-    , ("kbs",   EvKey KBS        [])
-    , ("kbeg",  EvKey KBegin     [])
-    , ("kcbt",  EvKey KBackTab   [])
-    , ("kc1",   EvKey KDownLeft  [])
-    , ("kc3",   EvKey KDownRight [])
-    , ("kdch1", EvKey KDel       [])
-    , ("kcud1", EvKey KDown      [])
-    , ("kend",  EvKey KEnd       [])
-    , ("kent",  EvKey KEnter     [])
-    , ("khome", EvKey KHome      [])
-    , ("kich1", EvKey KIns       [])
-    , ("kcub1", EvKey KLeft      [])
-    , ("knp",   EvKey KPageDown  [])
-    , ("kpp",   EvKey KPageUp    [])
-    , ("kcuf1", EvKey KRight     [])
-    , ("kDC",   EvKey KDel       [MShift])
-    , ("kEND",  EvKey KEnd       [MShift])
-    , ("kHOM",  EvKey KHome      [MShift])
-    , ("kIC",   EvKey KIns       [MShift])
-    , ("kLFT",  EvKey KLeft      [MShift])
-    , ("kRIT",  EvKey KRight     [MShift])
-    , ("kcuu1", EvKey KUp        [])
-    ] 

--- a/src/Graphics/Vty/Platform/Windows/Input/Terminfo/ANSIVT.hs
+++ b/src/Graphics/Vty/Platform/Windows/Input/Terminfo/ANSIVT.hs
@@ -1,10 +1,5 @@
--- | Input mappings for ANSI/VT100/VT50 terminals that is missing from
--- terminfo.
---
--- Or that are sent regardless of terminfo by terminal emulators. EG:
--- Terminal emulators will often use VT50 input bytes regardless of
--- declared terminal type. This provides compatibility with programs
--- that don't follow terminfo.
+-- | Input mappings for Windows terminals 
+-- pulled directly from https://learn.microsoft.com/en-us/windows/console/console-virtual-terminal-sequences#input-sequences
 module Graphics.Vty.Platform.Windows.Input.Terminfo.ANSIVT
   ( classifyTable
   )
@@ -14,103 +9,72 @@ import Graphics.Vty.Input.Events
 
 classifyTable :: [ClassifyMap]
 classifyTable =
-    [ navKeys0
-    , navKeys1
-    , navKeys2
-    , navKeys3
-    , functionKeysMap
-    , [("\ESC[Z", EvKey KBackTab [])]  -- don't forget poor little backtab
+    [ cursorKeysMap
+    , numpadAndF5ToF12
+    , functionKeys1To4
     ]
 
--- | Encoding for navigation keys.
-navKeys0 :: ClassifyMap
-navKeys0 =
-    [ k "G" KCenter
-    , k "P" KPause
-    , k "A" KUp
-    , k "B" KDown
-    , k "C" KRight
-    , k "D" KLeft
-    , k "H" KHome
-    , k "F" KEnd
-    , k "E" KBegin
-    ]
-    where k c s = ("\ESC[" ++ c, EvKey s [])
-
--- | encoding for shift, meta and ctrl plus arrows/home/end
-navKeys1 :: ClassifyMap
-navKeys1 =
-   [("\ESC[" ++ charCnt ++ show mc ++ c, EvKey s m)
-    | charCnt <- ["1;", ""], -- we can have a count or not
-    (m,mc) <- [([MShift],2::Int), ([MCtrl],5), ([MMeta],3),
-               -- modifiers and their codes
-               ([MShift, MCtrl],6), ([MShift, MMeta],4)],
-    -- directions and their codes
-    (c,s) <- [("A", KUp), ("B", KDown), ("C", KRight), ("D", KLeft), ("H", KHome), ("F", KEnd)]
-   ]
-
--- | encoding for ins, del, pageup, pagedown, home, end
-navKeys2 :: ClassifyMap
-navKeys2 =
-    let k n s = ("\ESC[" ++ show n ++ "~", EvKey s [])
-    in zipWith k [2::Int,3,5,6,1,4]
-                 [KIns,KDel,KPageUp,KPageDown,KHome,KEnd]
-
--- | encoding for ctrl + ins, del, pageup, pagedown, home, end
-navKeys3 :: ClassifyMap
-navKeys3 =
-    let k n s = ("\ESC[" ++ show n ++ ";5~", EvKey s [MCtrl])
-    in zipWith k [2::Int,3,5,6,1,4]
-                 [KIns,KDel,KPageUp,KPageDown,KHome,KEnd]
-
-
--- pulled directly from https://learn.microsoft.com/en-us/windows/console/console-virtual-terminal-sequences#numpad--function-keysfunctionKeysMap :: ClassifyMap
-functionKeysMap :: ClassifyMap
-functionKeysMap =
-  [ ("\ESCOP", EvKey (KFun 1) []),
-    ("\ESCOQ", EvKey (KFun 2) []),
-    ("\ESCOR", EvKey (KFun 3) []),
-    ("\ESCOS", EvKey (KFun 4) []),
-    ("\ESC[15~", EvKey (KFun 5) []),
-    ("\ESC[17~", EvKey (KFun 6) []),
-    ("\ESC[18~", EvKey (KFun 7) []),
-    ("\ESC[19~", EvKey (KFun 8) []),
-    ("\ESC[20~", EvKey (KFun 9) []),
-    ("\ESC[21~", EvKey (KFun 10) []),
-    ("\ESC[23~", EvKey (KFun 11) []), -- in default WT this is get intercepted by "toggle fullscreen"
-    ("\ESC[24~", EvKey (KFun 12) [])
+-- | Encoding for cursor keys.
+cursorKeysMap :: ClassifyMap
+cursorKeysMap =
+  [("\ESC[" ++ prefix mods ++ infx ++ name, EvKey key mods)
+    | (name, key) <-
+        [ ("A", KUp)
+        , ("B", KDown)
+        , ("C", KRight)
+        , ("D", KLeft)
+        , ("F", KEnd)
+        , ("H", KHome)
+        ]
+    , (infx, mods) <- modMap
   ]
-  <> (merger <$> conhostModifiers <*> conhostFnBase)
+  where
+    prefix mods = if null mods then "" else "1"
 
--- We have both Meta and Alt in the modifier
--- had to pick one, went with MEta for consistency
-conhostModifiers :: [(String, [Modifier])]
-conhostModifiers =
-  [ (";2", [MShift]),
+-- | encoding for numpad keys and F5 through F12
+numpadAndF5ToF12 :: ClassifyMap
+numpadAndF5ToF12 =
+  [ ("\ESC[" ++ name ++ infx ++ "~", EvKey key mods)
+    | (name, key) <-
+        [ ("2", KIns)
+        , ("3", KDel)
+        , ("5", KPageUp)
+        , ("6", KPageDown)
+        , ("15", KFun 5)
+        , ("17", KFun 6)
+        , ("18", KFun 7)
+        , ("19", KFun 8)
+        , ("20", KFun 9)
+        , ("21", KFun 10)
+        , ("23", KFun 11)
+        , ("24", KFun 12)
+        ]
+    , (infx, mods) <- modMap
+  ]
+
+-- | encoding for F1 through F4
+functionKeys1To4 :: ClassifyMap
+functionKeys1To4 =
+  [ ("\ESC" ++ prefix mods ++ infx ++ name, EvKey key mods)
+  | (name, key) <-
+      [ ("P", KFun 1),
+        ("Q", KFun 2),
+        ("R", KFun 3),
+        ("S", KFun 4)
+      ]
+  , (infx, mods) <- modMap
+  ]
+  where
+    prefix mods = if null mods then "O" else "[1"
+
+modMap :: [(String, [Modifier])]
+modMap =
+  [ ("", []),
+    (";2", [MShift]),
     (";3", [MMeta]),
     (";4", [MMeta, MShift]),
     (";5", [MCtrl]),
     (";6", [MCtrl, MShift]),
     (";7", [MMeta, MCtrl]),
     (";8", [MMeta, MCtrl, MShift])
-    -- I do not know whether ";1" is used
   ]
-
-conhostFnBase :: [((String, String), Int)]
-conhostFnBase =
-  [ (("\ESC[1","P"),  1),
-    (("\ESC[1","Q"),  2),
-    (("\ESC[1","R"),  3),
-    (("\ESC[1","S"),  4),
-    (("\ESC[15","~"), 5),
-    (("\ESC[17","~"), 6),
-    (("\ESC[18","~"), 7),
-    (("\ESC[19","~"), 8),
-    (("\ESC[20","~"), 9),
-    (("\ESC[21","~"), 10),
-    (("\ESC[23","~"), 11),
-    (("\ESC[24","~"), 12)
-  ]
-
-merger :: (String, [Modifier]) -> ((String, String), Int) -> (String, Event)
-merger (infx, mods) ((prefix, suffix), btn) = (prefix <> infx <> suffix, EvKey (KFun btn) mods)

--- a/src/Graphics/Vty/Platform/Windows/Input/Terminfo/ANSIVT.hs
+++ b/src/Graphics/Vty/Platform/Windows/Input/Terminfo/ANSIVT.hs
@@ -12,7 +12,15 @@ where
 
 import Graphics.Vty.Input.Events
 
--- Thanks to ShrykeWindGrace for the following code to properly handle ANSI character VT sequences...
+classifyTable :: [ClassifyMap]
+classifyTable =
+    [ navKeys0
+    , navKeys1
+    , navKeys2
+    , navKeys3
+    , functionKeysMap
+    , [("\ESC[Z", EvKey KBackTab [])]  -- don't forget poor little backtab
+    ]
 
 -- | Encoding for navigation keys.
 navKeys0 :: ClassifyMap
@@ -27,12 +35,12 @@ navKeys0 =
     , k "F" KEnd
     , k "E" KBegin
     ]
-    where k c s = ("\ESC["++c,EvKey s [])
+    where k c s = ("\ESC[" ++ c, EvKey s [])
 
 -- | encoding for shift, meta and ctrl plus arrows/home/end
 navKeys1 :: ClassifyMap
 navKeys1 =
-   [("\ESC[" ++ charCnt ++ show mc++c,EvKey s m)
+   [("\ESC[" ++ charCnt ++ show mc ++ c, EvKey s m)
     | charCnt <- ["1;", ""], -- we can have a count or not
     (m,mc) <- [([MShift],2::Int), ([MCtrl],5), ([MMeta],3),
                -- modifiers and their codes
@@ -44,51 +52,65 @@ navKeys1 =
 -- | encoding for ins, del, pageup, pagedown, home, end
 navKeys2 :: ClassifyMap
 navKeys2 =
-    let k n s = ("\ESC["++show n++"~",EvKey s [])
+    let k n s = ("\ESC[" ++ show n ++ "~", EvKey s [])
     in zipWith k [2::Int,3,5,6,1,4]
                  [KIns,KDel,KPageUp,KPageDown,KHome,KEnd]
 
 -- | encoding for ctrl + ins, del, pageup, pagedown, home, end
 navKeys3 :: ClassifyMap
 navKeys3 =
-    let k n s = ("\ESC["++show n++";5~",EvKey s [MCtrl])
+    let k n s = ("\ESC[" ++ show n ++ ";5~", EvKey s [MCtrl])
     in zipWith k [2::Int,3,5,6,1,4]
                  [KIns,KDel,KPageUp,KPageDown,KHome,KEnd]
 
--- | encoding for shift plus function keys
---
--- According to
---
---  * http://aperiodic.net/phil/archives/Geekery/term-function-keys.html
---
--- This encoding depends on the terminal.
--- functionKeys1 :: ClassifyMap
--- functionKeys1 =
---     let f ff nrs m = [ ("\ESC["++show n++"~",EvKey (KFun $ n-head nrs+ff) m) | n <- nrs ] in
---     concat [f 1 [25,26] [MShift], f 3 [28,29] [MShift], f 5 [31..34] [MShift] ]
 
--- | encoding for meta plus char
---
--- 1. removed 'ESC' from second list due to duplication with
--- "special_support_keys".
--- 2. removed '[' from second list due to conflict with 7-bit encoding
--- for ESC. Whether meta+[ is the same as ESC should examine km and
--- current encoding.
--- 3. stopped enumeration at '~' instead of '\DEL'. The latter is mapped
--- to KBS by special_support_keys.
-functionKeys2 :: ClassifyMap
-functionKeys2 = [ ('\ESC':[x],EvKey (KChar x) [MMeta])
-                  | x <- '\t':[' ' .. '~']
-                  , x /= '['
-                  , x /= 'z'
-                  ]
+-- pulled directly from https://learn.microsoft.com/en-us/windows/console/console-virtual-terminal-sequences#numpad--function-keysfunctionKeysMap :: ClassifyMap
+functionKeysMap :: ClassifyMap
+functionKeysMap =
+  [ ("\ESCOP", EvKey (KFun 1) []),
+    ("\ESCOQ", EvKey (KFun 2) []),
+    ("\ESCOR", EvKey (KFun 3) []),
+    ("\ESCOS", EvKey (KFun 4) []),
+    ("\ESC[15~", EvKey (KFun 5) []),
+    ("\ESC[17~", EvKey (KFun 6) []),
+    ("\ESC[18~", EvKey (KFun 7) []),
+    ("\ESC[19~", EvKey (KFun 8) []),
+    ("\ESC[20~", EvKey (KFun 9) []),
+    ("\ESC[21~", EvKey (KFun 10) []),
+    ("\ESC[23~", EvKey (KFun 11) []), -- in default WT this is get intercepted by "toggle fullscreen"
+    ("\ESC[24~", EvKey (KFun 12) [])
+  ]
+  <> (merger <$> conhostModifiers <*> conhostFnBase)
 
-classifyTable :: [ClassifyMap]
-classifyTable =
-    [ navKeys0
-    , navKeys1
-    , navKeys2
-    , navKeys3
-    -- , functionKeys1
-    , functionKeys2
-    ]
+-- We have both Meta and Alt in the modifier
+-- had to pick one, went with MEta for consistency
+conhostModifiers :: [(String, [Modifier])]
+conhostModifiers =
+  [ (";2", [MShift]),
+    (";3", [MMeta]),
+    (";4", [MMeta, MShift]),
+    (";5", [MCtrl]),
+    (";6", [MCtrl, MShift]),
+    (";7", [MMeta, MCtrl]),
+    (";8", [MMeta, MCtrl, MShift])
+    -- I do not know whether ";1" is used
+  ]
+
+conhostFnBase :: [((String, String), Int)]
+conhostFnBase =
+  [ (("\ESC[1","P"),  1),
+    (("\ESC[1","Q"),  2),
+    (("\ESC[1","R"),  3),
+    (("\ESC[1","S"),  4),
+    (("\ESC[15","~"), 5),
+    (("\ESC[17","~"), 6),
+    (("\ESC[18","~"), 7),
+    (("\ESC[19","~"), 8),
+    (("\ESC[20","~"), 9),
+    (("\ESC[21","~"), 10),
+    (("\ESC[23","~"), 11),
+    (("\ESC[24","~"), 12)
+  ]
+
+merger :: (String, [Modifier]) -> ((String, String), Int) -> (String, Event)
+merger (infx, mods) ((prefix, suffix), btn) = (prefix <> infx <> suffix, EvKey (KFun btn) mods)

--- a/src/Graphics/Vty/Platform/Windows/Output/Color.hs
+++ b/src/Graphics/Vty/Platform/Windows/Output/Color.hs
@@ -24,6 +24,7 @@ detectColorMode :: String -> IO ColorMode
 detectColorMode termType =
   case termType of
     "xterm-256color" -> return $ ColorMode240 255
+    "xterm"           -> return $ ColorMode240 255
     _                -> throwIO $ VtyUnsupportedTermType termType
 
 defaultColorMode :: IO ColorMode


### PR DESCRIPTION
There were numerous errors and inconsistencies in the way input sequences were parsed, which have now been fixed.
UTF8 initialization was removed - not necessary for Windows.
And finally, Windows UTF16 input processing code was cleaned up.

